### PR TITLE
Add transcript logging to live audio

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,3 +3,23 @@ body {
   align-items: center;
   justify-content: center;
 }
+
+.transcript {
+  position: absolute;
+  bottom: 20vh;
+  left: 0;
+  right: 0;
+  max-height: 40vh;
+  overflow-y: auto;
+  color: white;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.transcript .user {
+  text-align: right;
+}
+
+.transcript .model {
+  text-align: left;
+}

--- a/index.tsx
+++ b/index.tsx
@@ -165,6 +165,23 @@ export class GdmLiveAudio extends LitElement {
             this.updateStatus('Opened');
           },
           onmessage: async (message: LiveServerMessage) => {
+            const userSpeech = message.serverContent?.inputTranscription?.text;
+            const modelSpeech = message.serverContent?.outputTranscription?.text;
+            if (userSpeech) {
+              console.log('user:', userSpeech);
+              this.conversationHistory = [
+                ...this.conversationHistory,
+                {text: userSpeech, isUser: true},
+              ];
+            }
+            if (modelSpeech) {
+              console.log('model:', modelSpeech);
+              this.conversationHistory = [
+                ...this.conversationHistory,
+                {text: modelSpeech, isUser: false},
+              ];
+            }
+
             const audio =
               message.serverContent?.modelTurn?.parts[0]?.inlineData;
 
@@ -209,7 +226,7 @@ export class GdmLiveAudio extends LitElement {
           },
         },
         config: {
-          responseModalities: [Modality.AUDIO],
+          responseModalities: [Modality.AUDIO, Modality.TEXT],
           speechConfig: {
             voiceConfig: {prebuiltVoiceConfig: {voiceName: this.selectedVoice}},
           },
@@ -369,12 +386,23 @@ export class GdmLiveAudio extends LitElement {
               <rect x="0" y="0" width="100" height="100" rx="15" />
             </svg>
           </button>
+          <button id="toggleTranscript" @click=${this.toggleConversation}>
+            ${this.showConversation ? 'Hide Transcript' : 'Show Transcript'}
+          </button>
         </div>
 
         <div id="status"> ${this.error} </div>
         <gdm-live-audio-visuals-3d
           .inputNode=${this.inputNode}
           .outputNode=${this.outputNode}></gdm-live-audio-visuals-3d>
+        ${this.showConversation ? html`
+          <div class="transcript">
+            ${this.conversationHistory.map(item => html`
+              <div class=${item.isUser ? 'user' : 'model'}>
+                ${item.text}
+              </div>`)}
+          </div>
+        ` : null}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
- log user and model text from LiveServerMessage
- show a toggleable transcript display
- include Modality.TEXT in connection config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d72d05acc83268bcdd53332ced924