### PR TITLE
Add transcript logging to live audio

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,3 +3,23 @@ body {
   align-items: center;
   justify-content: center;
 }
+
+.transcript {
+  position: absolute;
+  bottom: 20vh;
+  left: 0;
+  right: 0;
+  max-height: 40vh;
+  overflow-y: auto;
+  color: white;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.transcript .user {
+  text-align: right;
+}
+
+.transcript .model {
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- log user and model text from LiveServerMessage
- show a toggleable transcript display
- include Modality.TEXT in connection config
- scroll transcript to bottom when new messages arrive
- ignore audio chunks after socket closes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d72d05acc83268bcdd53332ced924